### PR TITLE
rolled R version back to 3.5, tests pass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(person("F. William", "Townes", email = "will.townes@gmail.com",
             person("Jake", "Yeung", email = "jakeyeung@gmail.com", role="ctb"))
 License: Artistic-2.0
 Depends:
-    R (>= 3.6),
+    R (>= 3.5),
     stats
 Imports:
 Suggests:


### PR DESCRIPTION
A lot of people who might want to use this may not have the newest version of R, and this passes the included tests.

I've also run and verified that the images in the vignette are recreated without issue.
![glmpca_results](https://user-images.githubusercontent.com/1509626/66078396-f188aa80-e52f-11e9-959c-74d94f176a06.png)
